### PR TITLE
Keep context while exporting json-properties

### DIFF
--- a/exporters/json-properties.js
+++ b/exporters/json-properties.js
@@ -2,9 +2,21 @@ var fs = require('fs');
 
 function convertListToMap(list) {
     var termToTranslationMap = {};
+
     list.forEach(function (t) {
-        termToTranslationMap[t.term] = t.definition.form;
+        var form = t.definition.form;
+        var term = t.term;
+        var context = t.context.replace(/^"(.*)"$/, '$1');
+
+        if (context && !termToTranslationMap[context]) {
+            termToTranslationMap[context] = {};
+        }
+
+        context
+            ? termToTranslationMap[context][term] = form
+            : termToTranslationMap[term] = form;
     });
+
     return termToTranslationMap;
 }
 


### PR DESCRIPTION
Currently terms' context is being lost while exporting key-value json. If we export manually via https://poeditor.com, context is preserved as another nesting level:
```
{
    "term1": "phrase1",
    "context": {
        "term2": "phrase2",
        "term3": "phrase3"
    }
}
```
This gets trimmed to
```
{
    "term1": "phrase1",
    "term2": "phrase2",
    "term3": "phrase3"
}
```
The PR fixes that and adds context support.